### PR TITLE
add matchAny_zeroOrMore test

### DIFF
--- a/src/test/java/com/alexeygrigorev/rseq/WordMatcherTest.java
+++ b/src/test/java/com/alexeygrigorev/rseq/WordMatcherTest.java
@@ -709,6 +709,18 @@ public class WordMatcherTest {
         assertEquals(expectedResult, result);
     }
 
+    @Test
+    public void matchAny_zeroOrMore() {
+        List<Word> sentence = sentence("one/NN", "two/NN");
+        XMatcher<Word> any = Matchers.anything();
+        Pattern<Word> pattern = Pattern.create(word("one").captureAs("one"), any.zeroOrMore(), word("two").captureAs("two"));
+        List<Match<Word>> matches = pattern.find(sentence);
+        assertEquals(1, matches.size());
+        Match<Word> match = matches.get(0);
+        assertEquals("one", match.getVariable("one"));
+        assertEquals("two", match.getVariable("two"));
+    }
+
     public static List<Word> sentence(String... words) {
         List<Word> res = new ArrayList<Word>();
         for (String word : words) {

--- a/src/test/java/com/alexeygrigorev/rseq/WordMatcherTest.java
+++ b/src/test/java/com/alexeygrigorev/rseq/WordMatcherTest.java
@@ -710,15 +710,27 @@ public class WordMatcherTest {
     }
 
     @Test
-    public void matchAny_zeroOrMore() {
+    public void matchAny_zeroOrMore_ok() {
+        List<Word> sentence = sentence("one/NN", ",/NN", "two/NN");
+        XMatcher<Word> any = Matchers.anything();
+        Pattern<Word> pattern = Pattern.create(word("one").captureAs("one"), any.zeroOrMore(), word("two").captureAs("two"));
+        List<Match<Word>> matches = pattern.find(sentence);
+        assertEquals(1, matches.size());
+        Match<Word> match = matches.get(0);
+        assertEquals("one", match.getVariable("one").getToken());
+        assertEquals("two", match.getVariable("two").getToken());
+    }
+
+    @Test
+    public void matchAny_zeroOrMore_flawed() {
         List<Word> sentence = sentence("one/NN", "two/NN");
         XMatcher<Word> any = Matchers.anything();
         Pattern<Word> pattern = Pattern.create(word("one").captureAs("one"), any.zeroOrMore(), word("two").captureAs("two"));
         List<Match<Word>> matches = pattern.find(sentence);
         assertEquals(1, matches.size());
         Match<Word> match = matches.get(0);
-        assertEquals("one", match.getVariable("one"));
-        assertEquals("two", match.getVariable("two"));
+        assertEquals("one", match.getVariable("one").getToken());
+        assertEquals("two", match.getVariable("two").getToken());
     }
 
     public static List<Word> sentence(String... words) {


### PR DESCRIPTION
I found an issue with the library that is most easily explained by a unit test. 
I wanted to use this to calculate the distance between two words in a sentence so I thought just use the any matcher to match anything between. This does not seem to work in conjunction with the zeroOrMore() option.

This can probably be incorporated into one of the existing test cases but for clarity I kept it separate.